### PR TITLE
Fix generics and add preload field

### DIFF
--- a/src/p5/p5instance_logic.nim
+++ b/src/p5/p5instance_logic.nim
@@ -1,5 +1,6 @@
 import std / [macros, macrocache]
 from std/strutils import `%`
+import strformat
 
 import p5types
 
@@ -37,7 +38,8 @@ proc maybeReplaceCall(n: NimNode): NimNode =
     of nnkIdent, nnkSym: result = n
     of nnkCall: result = getName(n[0])
     of nnkDotExpr: result = getName(n[1]) # if it refers to a call, 2nd child is call
-    else: doAssert false, "Invalid branch as `maybeReplaceCall` expects nnkCall or nnkDotExpr"
+    of nnkBracketExpr: result = getName(n[0]) # generic function like newSeq[float]
+    else: doAssert false, &"Invalid branch ({n.kind}) as `maybeReplaceCall` expects nnkCall or nnkDotExpr"
 
   let name = getName(n)
   let nameIsWrapped = name in WrappedProcs
@@ -152,6 +154,10 @@ template instanceImpl(): untyped {.dirty.} =
 
   template draw(bd: untyped): untyped =
     p5Inst.draw = proc() =
+      replaceCalls(bd)
+
+  template preload(bd: untyped): untyped =
+    p5Inst.preload = proc() =
       replaceCalls(bd)
   ## XXX: define all templates from `p5sugar.nim`?
 

--- a/src/p5/p5types.nim
+++ b/src/p5/p5types.nim
@@ -62,6 +62,7 @@ type
     keyCode*: int
     setup*: Closure
     draw*: Closure
+    preload*: Closure
 
   InstanceClosure* = proc(s: P5Instance) {.closure.}
   Closure* = proc() {.closure.}


### PR DESCRIPTION
fixes #18 

This closes #18 so generics are handled in the instance mode and I also found that we don't have a `preload` field on the `P5Instance` object although we access it in the `preload` template (which I guess no-one has used :P).